### PR TITLE
infra: Add upload-artifact step when building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,11 @@ jobs:
         args: '-v -DPLANTUML_LIMIT_SIZE=8192 -tpng ${{ env.DOCS_DIR }}/puml/*.puml -o img'
     - name: Build documentation
       run: ${{ env.WORKFLOWS_DIR }}/build-docs
+    - name: Save documentation as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs_html
+        path: docs/_build/html
     - name: Deploy documentation
       if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release') }}
       uses: s0/git-publish-subdir-action@develop


### PR DESCRIPTION
Testing whether I can generate artifacts from the docs repo here and then use them in another workflow elsewhere to combine docs.